### PR TITLE
Update JIRA search URL to use /search/jql endpoint

### DIFF
--- a/lib/jira/resource/issue.rb
+++ b/lib/jira/resource/issue.rb
@@ -67,7 +67,7 @@ module JIRA
         result = []
         loop do
           url = client.options[:rest_base_path] +
-                "/search?expand=transitions.fields&maxResults=#{max_results}&startAt=#{start_at}"
+                "/search/jql?expand=transitions.fields&maxResults=#{max_results}&startAt=#{start_at}"
           response = client.get(url)
           json = parse_json(response.body)
           json['issues'].map do |issue|
@@ -81,7 +81,7 @@ module JIRA
       end
 
       def self.jql(client, jql, options = { fields: nil, start_at: nil, max_results: nil, expand: nil, validate_query: true })
-        url = client.options[:rest_base_path] + "/search?jql=#{CGI.escape(jql)}"
+        url = client.options[:rest_base_path] + "/search/jql?jql=#{CGI.escape(jql)}"
 
         if options[:fields]
           url << "&fields=#{options[:fields].map do |value|

--- a/lib/jira/resource/project.rb
+++ b/lib/jira/resource/project.rb
@@ -17,7 +17,7 @@ module JIRA
 
       # Returns all the issues for this project
       def issues(options = {})
-        search_url = "#{client.options[:rest_base_path]}/search"
+        search_url = "#{client.options[:rest_base_path]}/search/jql"
         query_params = { jql: "project=\"#{key}\"" }
         query_params.update Base.query_params_for_search(options)
         response = client.get(url_with_query_params(search_url, query_params))

--- a/spec/integration/issue_spec.rb
+++ b/spec/integration/issue_spec.rb
@@ -45,10 +45,10 @@ describe JIRA::Resource::Issue do
       end
 
       before do
-        stub_request(:get, "#{site_url}/jira/rest/api/2/search?expand=transitions.fields&maxResults=1000&startAt=0")
+        stub_request(:get, "#{site_url}/jira/rest/api/2/search/jql?expand=transitions.fields&maxResults=1000&startAt=0")
           .to_return(status: 200, body: get_mock_response('issue.json'))
 
-        stub_request(:get, "#{site_url}/jira/rest/api/2/search?expand=transitions.fields&maxResults=1000&startAt=11")
+        stub_request(:get, "#{site_url}/jira/rest/api/2/search/jql?expand=transitions.fields&maxResults=1000&startAt=11")
           .to_return(status: 200, body: get_mock_response('empty_issues.json'))
       end
 

--- a/spec/integration/project_spec.rb
+++ b/spec/integration/project_spec.rb
@@ -23,7 +23,7 @@ describe JIRA::Resource::Project do
 
     describe 'issues' do
       it 'returns all the issues' do
-        stub_request(:get, "#{site_url}/jira/rest/api/2/search?jql=project=\"SAMPLEPROJECT\"")
+        stub_request(:get, "#{site_url}/jira/rest/api/2/search/jql?jql=project=\"SAMPLEPROJECT\"")
           .to_return(status: 200, body: get_mock_response('project/SAMPLEPROJECT.issues.json'))
         subject = client.Project.build('key' => key)
         issues = subject.issues

--- a/spec/integration/rapidview_spec.rb
+++ b/spec/integration/rapidview_spec.rb
@@ -46,7 +46,7 @@ describe JIRA::Resource::RapidView do
 
         stub_request(
           :get,
-          "#{site_url}/jira/rest/api/2/search?jql=id IN(10001, 10000)"
+          "#{site_url}/jira/rest/api/2/search/jql?jql=id IN(10001, 10000)"
         ).to_return(
           status: 200,
           body: get_mock_response('rapidview/SAMPLEPROJECT.issues.full.json')
@@ -54,7 +54,7 @@ describe JIRA::Resource::RapidView do
 
         stub_request(
           :get,
-          "#{site_url}/jira/rest/api/2/search?jql=id IN(10000, 10001) AND sprint IS NOT EMPTY"
+          "#{site_url}/jira/rest/api/2/search/jql?jql=id IN(10000, 10001) AND sprint IS NOT EMPTY"
         ).to_return(
           status: 200,
           body: get_mock_response('rapidview/SAMPLEPROJECT.issues.full.json')

--- a/spec/jira/resource/agile_spec.rb
+++ b/spec/jira/resource/agile_spec.rb
@@ -31,7 +31,7 @@ describe JIRA::Resource::Agile do
       expect(client).to receive(:get).with('/jira/rest/agile/1.0/board/1/issue?').and_return(response)
       expect(response).to receive(:body).and_return(get_mock_response('board/1_issues.json'))
 
-      expect(client).to receive(:get).with('/jira/rest/api/2/search?jql=id+IN%2810546%2C+10547%2C+10556%2C+10557%2C+10558%2C+10559%2C+10600%2C+10601%2C+10604%29').and_return(response)
+      expect(client).to receive(:get).with('/jira/rest/api/2/search/jql?jql=id+IN%2810546%2C+10547%2C+10556%2C+10557%2C+10558%2C+10559%2C+10600%2C+10601%2C+10604%29').and_return(response)
       expect(response).to receive(:body).and_return(get_mock_response('board/1_issues.json'))
 
       issues = described_class.get_board_issues(client, 1)
@@ -48,7 +48,7 @@ describe JIRA::Resource::Agile do
       expect(client).to receive(:get).with('/jira/rest/agile/1.0/board/1/issue?startAt=50').and_return(response)
       expect(response).to receive(:body).and_return(get_mock_response('board/1_issues.json'))
 
-      expect(client).to receive(:get).with('/jira/rest/api/2/search?jql=id+IN%2810546%2C+10547%2C+10556%2C+10557%2C+10558%2C+10559%2C+10600%2C+10601%2C+10604%29').and_return(response)
+      expect(client).to receive(:get).with('/jira/rest/api/2/search/jql?jql=id+IN%2810546%2C+10547%2C+10556%2C+10557%2C+10558%2C+10559%2C+10600%2C+10601%2C+10604%29').and_return(response)
       expect(response).to receive(:body).and_return(get_mock_response('board/1_issues.json'))
 
       issues = described_class.get_board_issues(client, 1, startAt: 50)

--- a/spec/jira/resource/filter_spec.rb
+++ b/spec/jira/resource/filter_spec.rb
@@ -28,7 +28,7 @@ describe JIRA::Resource::Filter do
       owner: jira_user,
       jql: '"Git Repository" ~ jira-ruby AND status = Resolved',
       viewUrl: 'https://localhost/secure/IssueNavigator.jspa?mode=hide&requestId=42',
-      searchUrl: 'https://localhost/rest/api/2/search?jql=%22Git+Repository%22+~+jira-ruby+AND+status+%3D+Resolved',
+      searchUrl: 'https://localhost/rest/api/2/search/jql?jql=%22Git+Repository%22+~+jira-ruby+AND+status+%3D+Resolved',
       favourite: false,
       sharePermissions: [
         {
@@ -86,7 +86,7 @@ describe JIRA::Resource::Filter do
     expect(filter).to be_present
     allow(client).to receive(:options).and_return(rest_base_path: 'localhost')
     expect(client).to receive(:get)
-      .with("localhost/search?jql=#{CGI.escape(filter.jql)}")
+      .with("localhost/search/jql?jql=#{CGI.escape(filter.jql)}")
       .and_return(issue_jql_response)
     issues = filter.issues
     expect(issues).to be_an(Array)

--- a/spec/jira/resource/issue_spec.rb
+++ b/spec/jira/resource/issue_spec.rb
@@ -42,10 +42,10 @@ describe JIRA::Resource::Issue do
     issue = double
 
     allow(response).to receive(:body).and_return('{"issues":[{"id":"1","summary":"Bugs Everywhere"}]}')
-    expect(client).to receive(:get).with('/jira/rest/api/2/search?expand=transitions.fields&maxResults=1000&startAt=0')
+    expect(client).to receive(:get).with('/jira/rest/api/2/search/jql?expand=transitions.fields&maxResults=1000&startAt=0')
                                    .and_return(response)
     allow(empty_response).to receive(:body).and_return('{"issues":[]}')
-    expect(client).to receive(:get).with('/jira/rest/api/2/search?expand=transitions.fields&maxResults=1000&startAt=1')
+    expect(client).to receive(:get).with('/jira/rest/api/2/search/jql?expand=transitions.fields&maxResults=1000&startAt=1')
                                    .and_return(empty_response)
 
     expect(client).to receive(:Issue).and_return(issue)
@@ -75,7 +75,7 @@ describe JIRA::Resource::Issue do
     issue = double
 
     allow(response).to receive(:body).and_return('{"issues": {"key":"foo"}}')
-    expect(client).to receive(:get).with('/jira/rest/api/2/search?jql=foo+bar')
+    expect(client).to receive(:get).with('/jira/rest/api/2/search/jql?jql=foo+bar')
                                    .and_return(response)
     expect(client).to receive(:Issue).and_return(issue)
     expect(issue).to receive(:build).with(%w[key foo]).and_return('')

--- a/spec/jira/resource/project_spec.rb
+++ b/spec/jira/resource/project_spec.rb
@@ -42,7 +42,7 @@ describe JIRA::Resource::Project do
       issue_factory = double('issue factory')
 
       expect(client).to receive(:get)
-        .with('/jira/rest/api/2/search?jql=project%3D%22test%22')
+        .with('/jira/rest/api/2/search/jql?jql=project%3D%22test%22')
         .and_return(response)
       expect(client).to receive(:Issue).and_return(issue_factory)
       expect(issue_factory).to receive(:build)
@@ -58,7 +58,7 @@ describe JIRA::Resource::Project do
         issue_factory = double('issue factory')
 
         expect(client).to receive(:get)
-          .with('/jira/rest/api/2/search?jql=project%3D%22test%22&expand=changelog&startAt=1&maxResults=100')
+          .with('/jira/rest/api/2/search/jql?jql=project%3D%22test%22&expand=changelog&startAt=1&maxResults=100')
           .and_return(response)
         expect(client).to receive(:Issue).and_return(issue_factory)
         expect(issue_factory).to receive(:build)

--- a/spec/support/shared_examples/integration.rb
+++ b/spec/support/shared_examples/integration.rb
@@ -76,7 +76,7 @@ shared_examples 'a resource with JQL inputs and a collection GET endpoint' do
   it 'gets the collection' do
     stub_request(
       :get,
-      "#{site_url}#{client.options[:rest_base_path]}/search?jql=#{CGI.escape(jql_query_string)}"
+      "#{site_url}#{client.options[:rest_base_path]}/search/jql?jql=#{CGI.escape(jql_query_string)}"
     ).to_return(status: 200, body: get_mock_response('issue.json'))
 
     collection = build_receiver.jql(jql_query_string)


### PR DESCRIPTION
## Summary
- Updated the JIRA search URL from `/search` to `/search/jql` to align with newer JIRA REST API versions

## Changes
- Modified `lib/jira/resource/issue.rb` to use the `/search/jql` endpoint for both the `all` and `jql` methods
- This ensures compatibility with recent JIRA versions that have deprecated the `/search` endpoint in favor of `/search/jql`

## Test plan
- [ ] Verify that `JIRA::Resource::Issue.all` continues to work correctly
- [ ] Verify that `JIRA::Resource::Issue.jql` queries return expected results
- [ ] Test with different JIRA server versions if possible

🤖 Generated with [Claude Code](https://claude.ai/code)